### PR TITLE
Revision 0.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
-        "@sinclair/drift": "^0.9.0",
+        "@sinclair/drift": "^0.9.1",
         "@sinclair/hammer": "^0.18.0",
         "prettier": "^3.2.5",
         "typescript": "^5.4.3"
@@ -32,13 +32,13 @@
       }
     },
     "node_modules/@sinclair/drift": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@sinclair/drift/-/drift-0.9.0.tgz",
-      "integrity": "sha512-49bbd0rtd/L2SwuWlP3LigDZhEf3iICl1rXzD8QidrsZj9muDYpk57gTCblp4OYR/ImislWDq1Xmqrv30Vqpfg==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@sinclair/drift/-/drift-0.9.1.tgz",
+      "integrity": "sha512-Ggfionef6zxpGqqYaQomklIbblPzm6krejVX4KOFMqo4LPqwhDpvoD5Y7a190dBCfhd1BrrMSzknOFutoywhHg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.15.5",
-        "ws": "^8.8.1"
+        "ws": "^8.18.0"
       },
       "bin": {
         "drift": "start.mjs"
@@ -441,9 +441,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -471,13 +471,13 @@
       "optional": true
     },
     "@sinclair/drift": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@sinclair/drift/-/drift-0.9.0.tgz",
-      "integrity": "sha512-49bbd0rtd/L2SwuWlP3LigDZhEf3iICl1rXzD8QidrsZj9muDYpk57gTCblp4OYR/ImislWDq1Xmqrv30Vqpfg==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@sinclair/drift/-/drift-0.9.1.tgz",
+      "integrity": "sha512-Ggfionef6zxpGqqYaQomklIbblPzm6krejVX4KOFMqo4LPqwhDpvoD5Y7a190dBCfhd1BrrMSzknOFutoywhHg==",
       "dev": true,
       "requires": {
         "esbuild": "^0.15.5",
-        "ws": "^8.8.1"
+        "ws": "^8.18.0"
       }
     },
     "@sinclair/hammer": {
@@ -671,9 +671,9 @@
       "dev": true
     },
     "ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "requires": {}
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/smoke",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/smoke",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/drift": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "sinclair",
   "license": "MIT",
   "devDependencies": {
-    "@sinclair/drift": "^0.9.0",
+    "@sinclair/drift": "^0.9.1",
     "@sinclair/hammer": "^0.18.0",
     "prettier": "^3.2.5",
     "typescript": "^5.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/smoke",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Run Web Servers in Web Browsers over WebRTC",
   "type": "module",
   "main": "./index.mjs",

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ $ npm install @sinclair/smoke
 
 ## Overview
 
-Smoke is an experimental networking and storage framework for the browser that provides Http, Tcp and WebSocket emulation over WebRTC and large file storage via IndexedDB. It is built as a foundation for developing peer to peer services in the browser with each browser accessible via an application controlled virtual network.
+Smoke is an experimental browser networking and storage framework that provides Http, Tcp and WebSocket emulation over WebRTC and large file storage via IndexedDB. It is built as a foundation for developing peer to peer web services in the browser with each browser accessible via an application controlled virtual network.
 
 Smoke reshapes WebRTC into WinterCG compatible interfaces enabling traditional web server applications to be made portable between server and browser environments. It is developed in support of alternative software architectures where user centric services can be moved away from the cloud and run peer to peer in the browser.
 
@@ -143,7 +143,7 @@ const { Http } = new Network()
 <a name="Http-Listen"></a>
 ### Listen
 
-Use the Http listen function to receive Http requests from remote peers.
+Use the listen function to receive Http requests from remote peers.
 
 ```typescript
 Http.listen({ port: 5000 }, request => new Response('hello'))
@@ -152,7 +152,7 @@ Http.listen({ port: 5000 }, request => new Response('hello'))
 <a name="Http-Fetch"></a>
 ### Fetch
 
-Use Http fetch function to make a Http request to remote peers.
+Use the fetch function to make a Http request to remote peers.
 
 ```typescript
 const response = await Http.fetch('http://localhost:5000')
@@ -163,7 +163,7 @@ const message = await response.text()
 <a name="Http-Upgrade"></a>
 ### Upgrade
 
-Use upgrade function to convert a Http request into a WebSocket
+Use the upgrade function to convert a Http request into a WebSocket
 
 ```typescript
 Http.listen({ port: 5000 }, request => Http.upgrade(request, (socket) => socket.send('hello')))
@@ -172,7 +172,7 @@ Http.listen({ port: 5000 }, request => Http.upgrade(request, (socket) => socket.
 <a name="Http-Connect"></a>
 ### Connect
 
-Use connect function to establish a connection remote WebSocket server.
+Use the connect function to connect to a remote WebSocket server.
 
 ```typescript
 const socket = await Http.connect('ws://localhost:5000')
@@ -196,7 +196,7 @@ const { Net } = new Network()
 <a name="Net-Listen"></a>
 ### Listen
 
-Use the Net listen function to accept incoming sockets.
+Use the listen function to accept an incoming socket.
 
 ```typescript
 Net.listen({ port: 5000 }, async socket => {
@@ -236,7 +236,7 @@ const { Media } = new Network()
 <a name="Media-Listen"></a>
 ### Listen
 
-Use the listen function to listen for incoming MediaStream
+Use the listen function to listen for incoming MediaStream objects
 
 ```typescript
 Media.listen({ port: 6000 }, (receiver) => {
@@ -333,7 +333,7 @@ const exists = await Fs.exists('/path/file.txt')
 <a name="FileSystem-Mkdir"></a>
 ### Mkdir
 
-Use the mkdir function to recursively create a directory.
+Use the mkdir function to create a directory.
 
 ```typescript
 await Fs.mkdir('/media/videos')

--- a/src/net/socket.mts
+++ b/src/net/socket.mts
@@ -45,6 +45,7 @@ export class NetSocket implements Stream.Read<Uint8Array>, Stream.Write<Uint8Arr
     this.#mutex = new Async.Mutex()
     this.#readchannel = new Channel.Channel<Uint8Array>()
     this.#datachannel = datachannel
+    this.#datachannel.binaryType = 'arraybuffer'
     this.#datachannel.addEventListener('message', (event) => this.#onMessage(event))
     this.#datachannel.addEventListener('close', (event) => this.#onClose(event))
     this.#datachannel.addEventListener('error', (event) => this.#onError(event))


### PR DESCRIPTION
This PR specifies the binaryType property on RTCDataChannel instances. This to resolve disparities between Chrome and Firefox and enables Firefox to receive net connections.

Additional updates include:
- Update Drift tooling to resolve ws audit issue
- General readme copy updates.

Fixes: https://github.com/sinclairzx81/smoke/issues/24