### PR TITLE
Revision 0.8.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/smoke",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/smoke",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/drift": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/smoke",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Run Web Servers in Web Browsers over WebRTC",
   "type": "module",
   "main": "./index.mjs",

--- a/src/http/fetch.mts
+++ b/src/http/fetch.mts
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
 import { HttpListenerRequestInit, HttpListenerResponseInit } from './listener.mjs'
 
+import * as Async from '../async/index.mjs'
 import * as Buffer from '../buffer/index.mjs'
 import * as Stream from '../stream/index.mjs'
 import * as Net from '../net/index.mjs'
@@ -120,7 +121,7 @@ export async function fetch(net: Net.NetModule, endpoint: string, requestInit: R
   // send request body to server
   sendRequestBody(duplex, requestInit).catch((error) => console.error(error))
   // read server response signal
-  const signal = await readResponseSignal(duplex)
+  const signal = await Async.timeout(readResponseSignal(duplex), { timeout: 4000, error: new Error('A timeout occured reading the http response signal') })
   if (signal === null) {
     await duplex.close()
     throw Error(`Connection to ${endpoint} terminated unexpectedly`)
@@ -131,7 +132,7 @@ export async function fetch(net: Net.NetModule, endpoint: string, requestInit: R
     throw Error('Server is using alternate protocol')
   }
   // read server response init
-  const responseInit = await readListenerResponseInit(duplex)
+  const responseInit = await Async.timeout(readListenerResponseInit(duplex), { timeout: 4000, error: new Error('A timeout occured reading http response init') })
   if (responseInit === null) {
     await duplex.close()
     throw Error('Unable to parse server response headers')

--- a/test/index.mts
+++ b/test/index.mts
@@ -20,6 +20,12 @@ import './os/index.mjs'
 // Runner
 // ------------------------------------------------------------------
 declare const Drift: any
-Test.run({ filter: Drift.args[0] }).then((result) => {
-  return result.success ? Drift.close(0) : Drift.close(1)
-})
+if ('Drift' in globalThis) {
+  Test.run({ filter: Drift.args[0] }).then((result) => {
+    return result.success ? Drift.close(0) : Drift.close(1)
+  })
+} else {
+  Test.run({ filter: '' }).then((result) => {
+    console.log('done', result)
+  })
+}

--- a/test/test/reporter.mts
+++ b/test/test/reporter.mts
@@ -107,14 +107,17 @@ export class StdoutReporter implements Reporter {
   #write(message: string) {
     this.#writer.write(Buffer.encode(message))
   }
+  #ansi(message: string) {
+    this.#writer.write(Buffer.encode(message))
+  }
   // ----------------------------------------------------------------
   // Handlers
   // ----------------------------------------------------------------
   public onContextBegin(context: DescribeContext) {
     if (context.name === 'root') return
-    this.#write(Ansi.color.lightBlue)
+    this.#ansi(Ansi.color.lightBlue)
     this.#write(context.name)
-    this.#write(Ansi.reset)
+    this.#ansi(Ansi.reset)
     this.#newline()
   }
   public onContextEnd(context: DescribeContext) {
@@ -122,51 +125,51 @@ export class StdoutReporter implements Reporter {
     this.#newline()
   }
   public onUnitBegin(unit: ItContext) {
-    this.#write(Ansi.color.gray)
+    this.#ansi(Ansi.color.gray)
     this.#write(` - ${unit.name}`)
-    this.#write(Ansi.reset)
+    this.#ansi(Ansi.reset)
   }
   public onUnitEnd(unit: ItContext) {
     if (unit.error === null) {
-      this.#write(Ansi.color.green)
+      this.#ansi(Ansi.color.green)
       this.#write(` pass`)
-      this.#write(Ansi.reset)
-      this.#write(Ansi.color.lightBlue)
+      this.#ansi(Ansi.reset)
+      this.#ansi(Ansi.color.lightBlue)
       this.#write(` ${unit.elapsed.toFixed()} ms`)
-      this.#write(Ansi.reset)
+      this.#ansi(Ansi.reset)
     } else {
-      this.#write(Ansi.color.lightRed)
+      this.#ansi(Ansi.color.lightRed)
       this.#write(' fail')
-      this.#write(Ansi.reset)
+      this.#ansi(Ansi.reset)
     }
     this.#newline()
   }
   #printFailureSummary(context: DescribeContext) {
     for (const error of context.failures()) {
-      this.#write(Ansi.color.lightBlue)
+      this.#ansi(Ansi.color.lightBlue)
       this.#write(`${error.context} `)
-      this.#write(Ansi.reset)
-      this.#write(Ansi.color.gray)
+      this.#ansi(Ansi.reset)
+      this.#ansi(Ansi.color.gray)
       this.#write(`${error.unit}`)
-      this.#write(Ansi.reset)
+      this.#ansi(Ansi.reset)
       this.#newline()
       this.#newline()
 
       this.#write(Ansi.color.lightRed)
       this.#write(`  error`)
-      this.#write(Ansi.reset)
+      this.#ansi(Ansi.reset)
       this.#write(`:  ${error.error.message}`)
       this.#newline()
       if (error.error instanceof Assert.AssertError) {
-        this.#write(Ansi.color.lightGreen)
+        this.#ansi(Ansi.color.lightGreen)
         this.#write(`  expect`)
-        this.#write(Ansi.reset)
+        this.#ansi(Ansi.reset)
         this.#write(`: ${ValueFormatter.format(error.error.expect)}`)
         this.#newline()
 
-        this.#write(Ansi.color.lightRed)
+        this.#ansi(Ansi.color.lightRed)
         this.#write(`  actual`)
-        this.#write(Ansi.reset)
+        this.#ansi(Ansi.reset)
         this.#write(`: ${ValueFormatter.format(error.error.actual)}`)
         this.#newline()
       }
@@ -175,21 +178,21 @@ export class StdoutReporter implements Reporter {
     this.#newline()
   }
   #printCompletionSummary(context: DescribeContext) {
-    this.#write(Ansi.color.lightBlue)
+    this.#ansi(Ansi.color.lightBlue)
     this.#write('elapsed')
-    this.#write(Ansi.reset)
+    this.#ansi(Ansi.reset)
     this.#write(`: ${context.elapsed.toFixed(0)} ms`)
     this.#newline()
 
-    this.#write(Ansi.color.lightBlue)
+    this.#ansi(Ansi.color.lightBlue)
     this.#write('passed')
-    this.#write(Ansi.reset)
+    this.#ansi(Ansi.reset)
     this.#write(`:  ${context.passCount}`)
     this.#newline()
 
-    this.#write(Ansi.color.lightBlue)
+    this.#ansi(Ansi.color.lightBlue)
     this.#write('failed')
-    this.#write(Ansi.reset)
+    this.#ansi(Ansi.reset)
     this.#write(`:  ${context.failCount}`)
     this.#newline()
   }


### PR DESCRIPTION
This PR adds a hub terminate message that can be used to terminate the local and remote RTCPeerConnection in instances where the RTCPeerConnection enters into an inconsistent state.

Inconsistent connection states can be observed in Firefox where data channels created locally may not observed by the remote RTCPeerConnection. In smoke, this is usually detected by protocol handlers not receiving responses from the remote channel in instances where the local channel has opened. Once a peer connection has entered into a inconsistent state, no more connections can be created and the only recourse is to signal peer connection termination via the Hub.

This PR also implements better timeout handling in `fetch` specifically, additional timeout handling might be good for other protocol handlers, but will defer for a subsequent PR.

### Handling Firefox Issues

The following shows how to terminate connections in case of error. 

```typescript
import { Network } from '@sinclair/smoke'

const { Http, WebRtc } = new Network({ hub: ... })

// Assume we have a listener on localhost

Http.listen({ port: 5000 }, response => new Response('hello'))

// In Firefox, it is possible for the following to fail in instance the connection has become unstable.

try {

  const message = await Http.fetch('http://localhost:5000/index.html').then((x) => x.text())

  console.log(message)
  
} catch (error) {

   console.log('error')
   
   // terminate local and remote peer connections
   
   await WebRtc.terminate('localhost')
}
```
The above should allow subsequent fetches to work as smoke will reconstruct local and remote peers on next fetch. Implementations may wrap the above in a retry loop.