### PR TITLE
Revision 0.8.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/smoke",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/smoke",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/drift": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/smoke",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Run Web Servers in Web Browsers over WebRTC",
   "type": "module",
   "main": "./index.mjs",

--- a/src/agent/agent.mts
+++ b/src/agent/agent.mts
@@ -26,34 +26,20 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-// ------------------------------------------------------------------
-// Internal API
-// ------------------------------------------------------------------
+export type BrowserType = 'Firefox' | 'Chromium' | 'Safari' | 'Internet Explorer' | 'Unknown'
 
-export * as Agent from './agent/index.mjs'
-export * as Async from './async/index.mjs'
-export * as Buffer from './buffer/index.mjs'
-export * as Channel from './channel/index.mjs'
-export * as Crypto from './crypto/index.mjs'
-export * as Dispose from './dispose/index.mjs'
-export * as Events from './events/index.mjs'
-export * as FileSystem from './filesystem/index.mjs'
-export * as Hubs from './hubs/index.mjs'
-export * as IndexedDb from './indexeddb/index.mjs'
-export * as Os from './os/index.mjs'
-export * as Path from './path/index.mjs'
-export * as Stream from './stream/index.mjs'
-export * as Url from './url/index.mjs'
-
-// ------------------------------------------------------------------
-// Network Module API
-// ------------------------------------------------------------------
-export * from './http/index.mjs'
-export * from './media/index.mjs'
-export * from './net/index.mjs'
-export * from './webrtc/index.mjs'
-
-// ------------------------------------------------------------------
-// Network API
-// ------------------------------------------------------------------
-export { Network } from './network.mjs'
+/** Returns the Browser Type */
+export function browserType(): BrowserType {
+  const userAgent = navigator.userAgent.toLowerCase()
+  if (userAgent.includes('firefox')) {
+    return 'Firefox'
+  } else if (userAgent.includes('edg/') || (userAgent.includes('chrome') && !userAgent.includes('chromium'))) {
+    return 'Chromium'
+  } else if (userAgent.includes('safari') && !userAgent.includes('chrome') && !userAgent.includes('chromium')) {
+    return 'Safari'
+  } else if (userAgent.includes('msie') || userAgent.includes('trident/')) {
+    return 'Internet Explorer'
+  } else {
+    return 'Unknown'
+  }
+}

--- a/src/agent/index.mts
+++ b/src/agent/index.mts
@@ -26,34 +26,4 @@ THE SOFTWARE.
 
 ---------------------------------------------------------------------------*/
 
-// ------------------------------------------------------------------
-// Internal API
-// ------------------------------------------------------------------
-
-export * as Agent from './agent/index.mjs'
-export * as Async from './async/index.mjs'
-export * as Buffer from './buffer/index.mjs'
-export * as Channel from './channel/index.mjs'
-export * as Crypto from './crypto/index.mjs'
-export * as Dispose from './dispose/index.mjs'
-export * as Events from './events/index.mjs'
-export * as FileSystem from './filesystem/index.mjs'
-export * as Hubs from './hubs/index.mjs'
-export * as IndexedDb from './indexeddb/index.mjs'
-export * as Os from './os/index.mjs'
-export * as Path from './path/index.mjs'
-export * as Stream from './stream/index.mjs'
-export * as Url from './url/index.mjs'
-
-// ------------------------------------------------------------------
-// Network Module API
-// ------------------------------------------------------------------
-export * from './http/index.mjs'
-export * from './media/index.mjs'
-export * from './net/index.mjs'
-export * from './webrtc/index.mjs'
-
-// ------------------------------------------------------------------
-// Network API
-// ------------------------------------------------------------------
-export { Network } from './network.mjs'
+export * from './agent.mjs'


### PR DESCRIPTION
This PR Implements a Firefox fix for Http Request. The update implements a separate body resolution path for Firefox that yields a Blob object instead of a ReadableStream. It's noted that Firefox does not support ReadableStream on Request initialization (which is a long outstanding issue), but does correctly support Blobs.

This update also adds a `Agent` namespace which can be queried to learn of the users browser type.