### PR TITLE
Revision 0.8.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sinclair/smoke",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sinclair/smoke",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "license": "MIT",
       "devDependencies": {
         "@sinclair/drift": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinclair/smoke",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Run Web Servers in Web Browsers over WebRTC",
   "type": "module",
   "main": "./index.mjs",

--- a/src/net/socket.mts
+++ b/src/net/socket.mts
@@ -89,6 +89,7 @@ export class NetSocket implements Stream.Read<Uint8Array>, Stream.Write<Uint8Arr
     this.#readchannel.error(event as any)
   }
   #onMessage(event: MessageEvent) {
+    if(event.data instanceof ArrayBuffer) this.#peer.bytesReceived += event.data.byteLength
     this.#readchannel.send(new Uint8Array(event.data))
   }
   #onClose(event: Event) {
@@ -143,6 +144,7 @@ export class NetSocket implements Stream.Read<Uint8Array>, Stream.Write<Uint8Arr
         await this.#waitForMinimumWriteThreshold()
         const buffer = reader.read(this.#sendMessageSize())
         if (this.#isDataChannelOpen() && buffer !== null) {
+          this.#peer.bytesSent += buffer.byteLength
           this.#datachannel.send(buffer)
         } else {
           break


### PR DESCRIPTION
This PR adds a `.stats()` function to return current WebRTC network statistics. This is a synchronous function that can be called at relatively high frequency. The following is the API.

```typescript
import { Network } from '@sinclair/smoke'

const { WebRtc } = new Network({ ... })

const stats = WebRtc.stats()
```
This function will return an array of `WebRtcPeerStatistics` structures of the following form.

```typescript
// ------------------------------------------------------------------
// WebRtcPeerStatistic
// ------------------------------------------------------------------
export interface WebRtcPeerStatistic {
  /** The local address of this peer */
  localAddress: string
  /** The remote address of this peer */
  remoteAddress: string
  /** If this peer is making an offer */
  makingOffer: boolean
  /** If this peer is ignoring offers */
  ignoreOffer: boolean
  /** The number of bytes sent to this peer */
  bytesSent: number
  /** The number of bytes received from this peer */
  bytesReceived: number
  /** The number of send bytes being buffered for this peer */
  bytesBuffered: number
  /** The number of data channels being managed by this peer */
  channelCount: number
}
```

---

Note: As of this PR, the `bytesReceived` and `bytesSent` totals are accumulated inside the `NetModule` (not inside the `WebRtcModule`). While the `bytesReceived` could technically be handled via the `WebRtcModule`, this update holds that all interactions with a channel (including subscribing to message events) should be handled exterior to the `WebRtcModule` (where the `WebRtcModule` is limited to peer connection establishment only, not interactions with channels or media on that connection). 